### PR TITLE
fix: Add button styles to SCSS for Align game

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,12 @@
                     <p>A classic arcade game where you control a growing snake to eat food and avoid collisions.</p>
                     <a href="projects/game-snake/index.html">Play Snake</a>
                 </div>
+
+                <div class="project-item">
+                    <h3>Align Game</h3>
+                    <p>A puzzle game where you align pieces to solve the board.</p>
+                    <a href="projects/game-Align/index.html">Play Align</a>
+                </div>
             </div> 
         </section>
     </main>

--- a/projects/game-Align/index.html
+++ b/projects/game-Align/index.html
@@ -48,6 +48,9 @@
           <div class="blurb"></div>
           <div class="outlook"></div>
         </div>
+        <div class="back-to-home-container"> <!-- Added a container for styling -->
+          <a href="../../index.html" class="back-button">Back to OrygnsCode Home</a>
+        </div>
       </div>
       <div class="board">
         <div class="lit-columns">

--- a/projects/game-Align/styles/index.processed.css
+++ b/projects/game-Align/styles/index.processed.css
@@ -234,3 +234,28 @@ h2 {
     transform: translateY(0);
   }
 }
+
+/* Styles for Back to Home Button */
+.back-to-home-container {
+  margin-top: 20px;
+  text-align: center;
+}
+
+.back-button {
+  display: block; /* Changed from inline-block */
+  width: 100%;    /* Added */
+  padding: 2px 12px 4px; /* Changed */
+  font-family: inherit;
+  font-size: 24px; /* Changed */
+  border: solid 2px #ccc;
+  border-radius: 8px;
+  background-color: rgba(89, 63, 107, 0.7); /* Changed to rgba for transparency */
+  color: #fff;
+  text-decoration: none;
+  cursor: pointer;
+  box-sizing: border-box; /* Added to include padding and border in width calculation */
+}
+
+.back-button:hover {
+  background-color: rgba(89, 63, 107, 0.9); /* Changed to rgba, slightly less transparent */
+}

--- a/projects/game-Align/styles/index.scss
+++ b/projects/game-Align/styles/index.scss
@@ -214,6 +214,30 @@ h2 {
   }
 }
 
+.back-to-home-container {
+  margin-top: 20px;
+  text-align: center;
+
+  .back-button {
+    display: block;
+    width: 100%;
+    padding: 2px 12px 4px;
+    font-family: inherit; // Will inherit from .sidebar
+    font-size: 24px;
+    border: solid 2px #ccc; // Consider using a variable if one exists for #ccc
+    border-radius: 8px;
+    background-color: rgba(89, 63, 107, 0.7); // #593f6b with transparency
+    color: #fff; // Consider using a variable if one exists for #fff
+    text-decoration: none;
+    cursor: pointer;
+    box-sizing: border-box;
+
+    &:hover {
+      background-color: rgba(89, 63, 107, 0.9); // Slightly less transparent
+    }
+  }
+}
+
 @keyframes bounce {
   0% { animation-timing-function: ease-out; transform: translateY(0); }
   30% { animation-timing-function: ease-in; transform: translateY(-40px); }


### PR DESCRIPTION
Added the styles for the 'Back to Home' button and its container to the `projects/game-Align/styles/index.scss` file. This corrects an earlier oversight where styles were only applied to the processed CSS file.

The styles make the button visually similar to the 'Start Game' button but with transparency, as per previous feedback.

Note: The `index.scss` file will need to be recompiled to `index.processed.css` for these changes to take effect in the game.