### PR TITLE
refactor: Simplify controls display and mobile UX

### DIFF
--- a/projects/game-EndlessBoxyRun/index.html
+++ b/projects/game-EndlessBoxyRun/index.html
@@ -18,32 +18,32 @@
 				<p id="score">0</p>
 			</div>
 			<table id="controls">
-			  	<tr class="keyboard-control">
+			  	<tr>
 			    	<td>Up:</td>
 			    	<td>Jump</td>
 			  	</tr>
-			  	<tr class="keyboard-control">
+			  	<tr>
 			    	<td>Left:</td>
 			    	<td>Left lane switch</td>
 			  	</tr>
-			  	<tr class="keyboard-control">
+			  	<tr>
 			    	<td>Right:</td>
 			    	<td>Right lane switch</td>
 			  	</tr>
-			  	<tr class="keyboard-control">
+			  	<tr>
 			    	<td>p:</td>
 			    	<td>Pause</td>
 			  	</tr>
-			  	<tr class="swipe-control" style="display:none;">
-			    	<td>Swipe Up:</td>
+			  	<tr>
+			    	<td>Swipe Up (Mobile):</td>
 			    	<td>Jump</td>
 			  	</tr>
-			  	<tr class="swipe-control" style="display:none;">
-			    	<td>Swipe Left:</td>
+			  	<tr>
+			    	<td>Swipe Left (Mobile):</td>
 			    	<td>Left lane switch</td>
 			  	</tr>
-			  	<tr class="swipe-control" style="display:none;">
-			    	<td>Swipe Right:</td>
+			  	<tr>
+			    	<td>Swipe Right (Mobile):</td>
 			    	<td>Right lane switch</td>
 			  	</tr>
 			</table>
@@ -56,14 +56,5 @@
 		<div id="world"></div>
 			
 		</div>
-    <div id="mobile-instructions-overlay" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.8); color: white; z-index: 1000; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; padding: 20px; box-sizing: border-box;">
-        <div>
-            <h2 style="margin-bottom: 15px; font-size: 1.8em;">Controls</h2>
-            <p style="font-size: 1.2em; margin-bottom: 8px;">Swipe Up: Jump</p>
-            <p style="font-size: 1.2em; margin-bottom: 8px;">Swipe Left: Move Left</p>
-            <p style="font-size: 1.2em; margin-bottom: 25px;">Swipe Right: Move Right</p>
-            <p style="font-size: 1em; font-style: italic;">(Tap screen to start)</p>
-        </div>
-    </div>
 	</body>
 </html>


### PR DESCRIPTION
Reverts several mobile-specific UX features based on your feedback, aiming for a more universal experience across devices.

Key changes:
- Removed the full-screen mobile instructions overlay.
- Removed `isMobile` detection and all associated conditional logic (for game over messages, restart methods, controls display).
- Controls panel now displays all available controls (keyboard and swipe) to all users, with swipe controls labeled "(Mobile)".
- Game over message is now universal: "Game over! Press down arrow or tap screen to try again."
- Game restart is now universal: via down arrow key OR screen tap.
- Game start is now universal: via key press OR screen tap.

Responsive CSS for layout and previous game mechanic fixes remain intact.