### PR TITLE
Fix: Decrease letter spacing for AstroDuel title

### DIFF
--- a/projects/game-AstroDuel/style.css
+++ b/projects/game-AstroDuel/style.css
@@ -116,7 +116,7 @@ p.p2 {
 
 .vs {
   font-size: 5em;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.06em;
   padding: 0 0 0 0.2em; }
 
 .toggle {


### PR DESCRIPTION
Changed the letter-spacing property for the .vs class in projects/game-AstroDuel/style.css from 0.1em to 0.06em. This reduces the space between letters in the "AstroDuel" title by 40% as you requested.