### PR TITLE
Feat: Add control instructions under player type selection

### DIFF
--- a/projects/game-AstroDuel/index.html
+++ b/projects/game-AstroDuel/index.html
@@ -28,8 +28,10 @@
     <div class='popup-text'>
       <div class="options">
         <button id="playerOne" class="toggle button option-blue">Computer</button>
+        <div id="playerOneControls" class="controls-text">Controls W, A, S, D, Z to fire</div>
         <h2 class="vs">AstroDuel</h2>
         <button id="playerTwo" class="toggle button option-red">Human</button>
+        <div id="playerTwoControls" class="controls-text">Controls ↑, ↓, ←, →, Space to shoot</div>
       </div>
       <div class="options-lower">
         <button id="obstacles" class="toggle button option-obstacles">Asteroids: On</button>

--- a/projects/game-AstroDuel/script.js
+++ b/projects/game-AstroDuel/script.js
@@ -19,6 +19,9 @@ const space = document.querySelector(".space");
 // On the start screen there are buttons to toggle whether the player is a computer or human
 const playerOneToggle = document.querySelector("#playerOne");
 const playerTwoToggle = document.querySelector("#playerTwo");
+// Control instruction elements
+const playerOneControls = document.querySelector("#playerOneControls");
+const playerTwoControls = document.querySelector("#playerTwoControls");
 // There is also a toggle button for the asteroids to create variety in the game
 const asteroidsToggle = document.querySelector("#obstacles");
 // The gutter hides the new asteroids being added to the game so it is best to keep the rocket on screen to avoid being hit
@@ -933,11 +936,21 @@ function switchObstacles() {
 playerOneToggle.addEventListener("click", function() {
   playerOne = toggleOption(playerOne);
   this.textContent = switchPlayer(playerOne);
+  if (playerOne) { // Computer
+    playerOneControls.style.display = "none";
+  } else { // Human
+    playerOneControls.style.display = "block";
+  }
 });
 
 playerTwoToggle.addEventListener("click", function() {
   playerTwo = toggleOption(playerTwo);
   this.textContent = switchPlayer(playerTwo);
+  if (playerTwo) { // Computer
+    playerTwoControls.style.display = "none";
+  } else { // Human
+    playerTwoControls.style.display = "block";
+  }
 });
 asteroidsToggle.addEventListener("click", function() {
   obstacles = toggleOption(obstacles);
@@ -1137,6 +1150,19 @@ document.addEventListener("DOMContentLoaded", function(event) {
   placeElements();
   // Open the popup UI for the player
   openPopup();
+
+  // Set initial visibility of controls based on default player types
+  if (playerOne) { // Computer
+    playerOneControls.style.display = "none";
+  } else { // Human
+    playerOneControls.style.display = "block";
+  }
+  if (playerTwo) { // Computer
+    playerTwoControls.style.display = "none";
+  } else { // Human
+    playerTwoControls.style.display = "block";
+  }
+
   // Define keyboard functions
   document.addEventListener(
     "keydown",

--- a/projects/game-AstroDuel/style.css
+++ b/projects/game-AstroDuel/style.css
@@ -116,7 +116,7 @@ p.p2 {
 
 .vs {
   font-size: 5em;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.06em;
   padding: 0 0 0 0.2em; }
 
 .toggle {
@@ -135,6 +135,13 @@ p.p2 {
 
 .options button {
   position: relative; }
+
+.controls-text {
+  color: white;
+  display: none;
+  font-size: 0.6em;
+  margin-top: 0.5em;
+  text-align: center; }
 
 .options-lower {
   left: 50%;


### PR DESCRIPTION
This commit introduces the following changes:

- Added HTML elements to display control instructions for Player 1 (W, A, S, D, Z to fire) and Player 2 (↑, ↓, ←, →, Space to shoot) in `projects/game-AstroDuel/index.html`.
- Added CSS styles in `projects/game-AstroDuel/style.css` to format the control instructions, make them smaller than the player type buttons, and hide them by default.
- Updated `projects/game-AstroDuel/script.js` to dynamically show the control instructions only when a player is set to "Human". If "Computer" is selected, the instructions are hidden.
- Ensured the initial visibility of instructions is correctly set on page load based on default player types.