### PR TITLE
feat: Add 'Back to Home' button to AstroDuel and link from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,12 @@
             <h2>My Games</h2> 
             <div class="project-list">
                 <article class="project-item">
+                    <h3>AstroDuel</h3>
+                    <p>A space combat game.</p>
+                    <a href="projects/game-AstroDuel/index.html">Play AstroDuel</a>
+                </article>
+
+                <article class="project-item">
                     <h3>2048 Game</h3>
                     <p>A classic tile-merging puzzle game. Swipe or use arrow keys!</p>
                     <a href="projects/game-2048/index.html">Play 2048</a>

--- a/projects/game-AstroDuel/index.html
+++ b/projects/game-AstroDuel/index.html
@@ -35,6 +35,8 @@
         <button id="obstacles" class="toggle button option-obstacles">Asteroids: On</button>
         <br/>
         <button id="start" class="start-button">Start</button>
+        <br/>
+        <a href="../../index.html" class="start-button" id="backButton">Back to OrygnsCode Home</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This commit introduces two main changes:

1.  A "Back to OrygnsCode Home" button has been added to the AstroDuel game's main menu (`projects/game-AstroDuel/index.html`). This button allows you to easily navigate back to the main portfolio homepage. It is styled consistently with existing buttons.

2.  The AstroDuel game is now listed and accessible from the main homepage (`index.html`). A new project card has been added for AstroDuel, allowing you to launch the game directly from the homepage.