### PR TITLE
fix: Ensure 'Back to Home' button style matches other buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,12 @@
             <h2>My Games</h2> 
             <div class="project-list">
                 <article class="project-item">
+                    <h3>AstroDuel</h3>
+                    <p>A space combat game.</p>
+                    <a href="projects/game-AstroDuel/index.html">Play AstroDuel</a>
+                </article>
+
+                <article class="project-item">
                     <h3>2048 Game</h3>
                     <p>A classic tile-merging puzzle game. Swipe or use arrow keys!</p>
                     <a href="projects/game-2048/index.html">Play 2048</a>

--- a/projects/game-AstroDuel/index.html
+++ b/projects/game-AstroDuel/index.html
@@ -35,6 +35,8 @@
         <button id="obstacles" class="toggle button option-obstacles">Asteroids: On</button>
         <br/>
         <button id="start" class="start-button">Start</button>
+        <br/>
+        <a href="../../index.html" class="start-button" id="backButton">Back to OrygnsCode Home</a>
       </div>
     </div>
   </div>

--- a/projects/game-AstroDuel/style.css
+++ b/projects/game-AstroDuel/style.css
@@ -163,6 +163,22 @@ p.p2 {
   margin-top: 1em;
   z-index: 9999; }
 
+a.start-button {
+  display: inline-block;
+  border: 3px solid white;
+  color: white;
+  font-size: 22px;
+  font-weight: bold;
+  line-height: 1.2;
+  padding: 20px 32px;
+  min-height: 4.5em;
+  text-align: center;
+  text-decoration: none;
+  text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  /* Inherits background and margin-top from .start-button */
+}
+
 .popup-results {
   display: none;
   left: 50%;


### PR DESCRIPTION
This commit updates the CSS for the 'Back to OrygnsCode Home' button in the AstroDuel game.

A new CSS rule for 'a.start-button' has been added to projects/game-AstroDuel/style.css to ensure that the anchor-based button inherits all visual styling (font, padding, border, etc.) from the base button styles, making it visually identical to the <button> elements like the 'Start' button.