### PR TITLE
refactor: Refine 'Back to Home' button text layout and hover effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,12 @@
             <h2>My Games</h2> 
             <div class="project-list">
                 <article class="project-item">
+                    <h3>AstroDuel</h3>
+                    <p>A space combat game.</p>
+                    <a href="projects/game-AstroDuel/index.html">Play AstroDuel</a>
+                </article>
+
+                <article class="project-item">
                     <h3>2048 Game</h3>
                     <p>A classic tile-merging puzzle game. Swipe or use arrow keys!</p>
                     <a href="projects/game-2048/index.html">Play 2048</a>

--- a/projects/game-AstroDuel/index.html
+++ b/projects/game-AstroDuel/index.html
@@ -35,6 +35,8 @@
         <button id="obstacles" class="toggle button option-obstacles">Asteroids: On</button>
         <br/>
         <button id="start" class="start-button">Start</button>
+        <br/>
+        <a href="../../index.html" class="start-button" id="backButton">Back to OrygnsCode<br>Home</a>
       </div>
     </div>
   </div>

--- a/projects/game-AstroDuel/style.css
+++ b/projects/game-AstroDuel/style.css
@@ -163,6 +163,34 @@ p.p2 {
   margin-top: 1em;
   z-index: 9999; }
 
+a.start-button {
+  display: inline-block;
+  border: 3px solid white;
+  color: white;
+  font-size: 22px;
+  font-weight: bold;
+  line-height: 1.2;
+  padding: 20px 32px;
+  min-height: 4.5em;
+  text-align: center;
+  text-decoration: none;
+  text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  /* Inherits background and margin-top from .start-button */
+}
+
+a.start-button:hover {
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
+#backButton {
+  display: flex;
+  align-items: center; /* For vertical centering of content */
+  justify-content: center; /* For horizontal centering of content */
+  text-align: center; /* To ensure the text itself is centered if it wraps */
+  /* It will still inherit other styles like background, color, font, padding, border from a.start-button and .start-button */
+}
+
 .popup-results {
   display: none;
   left: 50%;


### PR DESCRIPTION
This commit applies further styling refinements to the 'Back to OrygnsCode Home' button in AstroDuel:

1.  Text Wrapping: The button text is now displayed on two lines ("Back to OrygnsCode" on the first, "Home" on the second) achieved by adding a <br> tag in the HTML.
2.  Text Centering: Flexbox properties (display: flex, align-items: center, justify-content: center) have been applied to #backButton in CSS to ensure the two-line text is perfectly centered horizontally and vertically within the button.
3.  Hover Effect: An 'a.start-button:hover' CSS rule has been added to change the border-color on mouse hover, matching the behavior of other buttons on the page.