### PR TITLE
feat: Add 'Main Menu' and 'Back to Home' buttons to game over screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,12 @@
             <h2>My Games</h2> 
             <div class="project-list">
                 <article class="project-item">
+                    <h3>AstroDuel</h3>
+                    <p>A space combat game.</p>
+                    <a href="projects/game-AstroDuel/index.html">Play AstroDuel</a>
+                </article>
+
+                <article class="project-item">
                     <h3>2048 Game</h3>
                     <p>A classic tile-merging puzzle game. Swipe or use arrow keys!</p>
                     <a href="projects/game-2048/index.html">Play 2048</a>

--- a/projects/game-AstroDuel/index.html
+++ b/projects/game-AstroDuel/index.html
@@ -35,6 +35,8 @@
         <button id="obstacles" class="toggle button option-obstacles">Asteroids: On</button>
         <br/>
         <button id="start" class="start-button">Start</button>
+        <br/>
+        <a href="../../index.html" class="start-button" id="backButton">Back to OrygnsCode<br>Home</a>
       </div>
     </div>
   </div>
@@ -44,6 +46,10 @@
       <h3 class="result"></h3>
       <h3 class="message"></h3>
       <button id="restart" class="start-button">Play Again?</button>
+      <br>
+      <button id="mainMenuButton" class="start-button">Main Menu</button>
+      <br>
+      <a href="../../index.html" class="start-button" id="backButtonResults">Back to OrygnsCode<br>Home</a>
     </div>
   </div>
   <!--RESULTS END-->

--- a/projects/game-AstroDuel/script.js
+++ b/projects/game-AstroDuel/script.js
@@ -1130,6 +1130,17 @@ function gameOver(target) {
   popup = document.getElementById("results");
   // Show the popup UI to the player
   openPopup();
+
+  // Get reference to the Main Menu button on the results screen
+  const resultsMainMenuButton = document.querySelector("#results #mainMenuButton");
+  // Check if it exists to prevent errors if HTML is out of sync
+  if (resultsMainMenuButton) {
+    resultsMainMenuButton.addEventListener('click', function handleGoToMainMenu() {
+      closePopup(); // Close the results popup
+      popup = document.getElementById('popup'); // IMPORTANT: Point back to the main menu popup
+      openPopup(); // Open the main menu popup
+    }, { once: true }); // Use { once: true } to auto-remove listener after first click
+  }
 }
 
 // Define what to do when the page loads

--- a/projects/game-AstroDuel/style.css
+++ b/projects/game-AstroDuel/style.css
@@ -163,6 +163,41 @@ p.p2 {
   margin-top: 1em;
   z-index: 9999; }
 
+a.start-button {
+  display: inline-block;
+  border: 3px solid white;
+  color: white;
+  font-size: 22px;
+  font-weight: bold;
+  line-height: 1.2;
+  padding: 20px 32px;
+  min-height: 4.5em;
+  text-align: center;
+  text-decoration: none;
+  text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  /* Inherits background and margin-top from .start-button */
+}
+
+a.start-button:hover {
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
+#backButton {
+  display: flex;
+  align-items: center; /* For vertical centering of content */
+  justify-content: center; /* For horizontal centering of content */
+  text-align: center; /* To ensure the text itself is centered if it wraps */
+  /* It will still inherit other styles like background, color, font, padding, border from a.start-button and .start-button */
+}
+
+#backButtonResults {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
 .popup-results {
   display: none;
   left: 50%;


### PR DESCRIPTION
This commit enhances the game over screen in AstroDuel by adding two new navigation buttons:

1.  HTML Changes:
    - A "Main Menu" button (`#mainMenuButton`) has been added below the "Play Again?" button on the results screen (`#results`).
    - A "Back to OrygnsCode Home" button (`#backButtonResults`), styled like the main menu's version (two-line centered text), has been added below the "Main Menu" button.

2.  CSS Changes:
    - Specific styles for `#backButtonResults` were added to ensure correct flexbox centering of its two-line text.

3.  JavaScript Changes:
    - Functionality for the "Main Menu" button has been implemented. Clicking it now hides the results popup, correctly resets the internal 'popup' variable to point to the main menu div, and then displays the main menu. The event listener uses `{ once: true }` for robustness.

These changes provide you with more navigation options after a game concludes.