### PR TITLE
refactor: Remove 'Back to Home' button from game over screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,12 @@
             <h2>My Games</h2> 
             <div class="project-list">
                 <article class="project-item">
+                    <h3>AstroDuel</h3>
+                    <p>A space combat game.</p>
+                    <a href="projects/game-AstroDuel/index.html">Play AstroDuel</a>
+                </article>
+
+                <article class="project-item">
                     <h3>2048 Game</h3>
                     <p>A classic tile-merging puzzle game. Swipe or use arrow keys!</p>
                     <a href="projects/game-2048/index.html">Play 2048</a>

--- a/projects/game-AstroDuel/index.html
+++ b/projects/game-AstroDuel/index.html
@@ -35,6 +35,8 @@
         <button id="obstacles" class="toggle button option-obstacles">Asteroids: On</button>
         <br/>
         <button id="start" class="start-button">Start</button>
+        <br/>
+        <a href="../../index.html" class="start-button" id="backButton">Back to OrygnsCode<br>Home</a>
       </div>
     </div>
   </div>
@@ -44,6 +46,8 @@
       <h3 class="result"></h3>
       <h3 class="message"></h3>
       <button id="restart" class="start-button">Play Again?</button>
+      <br>
+      <button id="mainMenuButton" class="start-button">Main Menu</button>
     </div>
   </div>
   <!--RESULTS END-->

--- a/projects/game-AstroDuel/script.js
+++ b/projects/game-AstroDuel/script.js
@@ -1130,6 +1130,17 @@ function gameOver(target) {
   popup = document.getElementById("results");
   // Show the popup UI to the player
   openPopup();
+
+  // Get reference to the Main Menu button on the results screen
+  const resultsMainMenuButton = document.querySelector("#results #mainMenuButton");
+  // Check if it exists to prevent errors if HTML is out of sync
+  if (resultsMainMenuButton) {
+    resultsMainMenuButton.addEventListener('click', function handleGoToMainMenu() {
+      closePopup(); // Close the results popup
+      popup = document.getElementById('popup'); // IMPORTANT: Point back to the main menu popup
+      openPopup(); // Open the main menu popup
+    }, { once: true }); // Use { once: true } to auto-remove listener after first click
+  }
 }
 
 // Define what to do when the page loads

--- a/projects/game-AstroDuel/style.css
+++ b/projects/game-AstroDuel/style.css
@@ -163,6 +163,34 @@ p.p2 {
   margin-top: 1em;
   z-index: 9999; }
 
+a.start-button {
+  display: inline-block;
+  border: 3px solid white;
+  color: white;
+  font-size: 22px;
+  font-weight: bold;
+  line-height: 1.2;
+  padding: 20px 32px;
+  min-height: 4.5em;
+  text-align: center;
+  text-decoration: none;
+  text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  /* Inherits background and margin-top from .start-button */
+}
+
+a.start-button:hover {
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
+#backButton {
+  display: flex;
+  align-items: center; /* For vertical centering of content */
+  justify-content: center; /* For horizontal centering of content */
+  text-align: center; /* To ensure the text itself is centered if it wraps */
+  /* It will still inherit other styles like background, color, font, padding, border from a.start-button and .start-button */
+}
+
 .popup-results {
   display: none;
   left: 50%;


### PR DESCRIPTION
This commit removes the "Back to OrygnsCode Home" button (previously `a#backButtonResults`) from the AstroDuel game over screen.

Changes include:
- Removed the `a#backButtonResults` HTML element and its preceding <br> tag from `projects/game-AstroDuel/index.html`.
- Removed the corresponding CSS rule for `#backButtonResults` from `projects/game-AstroDuel/style.css`.

This change simplifies the game over screen, as you can access the link to the OrygnsCode homepage via the main menu.