### PR TITLE
Fix: Correct 'Difficulty' text rendering

### DIFF
--- a/projects/game-Align/index.html
+++ b/projects/game-Align/index.html
@@ -7,7 +7,6 @@
   <title>Connect 4</title>
   
   <!--  Styles  -->
-  <link href="https://fonts.googleapis.com/css?family=Doppio+One" rel="stylesheet">
   <link rel="stylesheet" href="styles/index.processed.css">
 </head>
 <body>

--- a/projects/game-Align/styles/index.processed.css
+++ b/projects/game-Align/styles/index.processed.css
@@ -27,7 +27,7 @@ body {
   margin-right: 20px;
   width: 220px;
   text-align: left;
-  font-family: 'Doppio One', sans-serif;
+  font-family: sans-serif;
   color: #ccc;
 }
 


### PR DESCRIPTION
The word 'Difficulty' was rendering incorrectly due to an issue with the 'Doppio One' font, causing 'ff' to display as a strange character or emoji.

This fix removes the 'Doppio One' font and falls back to a standard sans-serif font, which resolves the rendering problem.