### PR TITLE
Fix: Correct layout and clickability of Tetris home link

### DIFF
--- a/projects/game-Tetris/index.html
+++ b/projects/game-Tetris/index.html
@@ -1,3 +1,4 @@
+<a id="homeLink" href="/" style="display:none;"></a>
 <div class="canvas-container">
     <canvas id="cnv" height="600px" width="600px"></canvas>
 </div>

--- a/projects/game-Tetris/script.js
+++ b/projects/game-Tetris/script.js
@@ -305,6 +305,10 @@ function drawUI() {
     ctx.textAlign = 'left';
     // Title or something
     ctx.fillText('Tetris',3,3);
+    ctx.font = '0.8px monospace';
+    ctx.fillText('Back to', 3, 4.2);
+    ctx.fillText('OrygnsCode Home', 3, 5.0);
+    ctx.font = '1px monospace'; // Reset font for subsequent text
     // Instructions
     ctx.fillText('← / → = Move Horizontally',6,25);
     ctx.fillText('↑ = Rotate    // SHIFT = Switch',6,26);
@@ -366,3 +370,45 @@ function randomPiece() {
 // ---------------------------------------------------------
 
 init();
+
+// --- Clickable Link for "Back to OrygnsCode Home" ---
+cnv.addEventListener('click', function(event) {
+    const clickX = event.offsetX / 20; // Scale factor is 20
+    const clickY = event.offsetY / 20; // Scale factor is 20
+
+    const textFont = '0.8px monospace';
+    const commonTextX = 3;
+    const commonTextHeight = 0.8; // Approximation
+
+    const previousFont = ctx.font;
+    ctx.font = textFont; // Set font for measurements
+
+    // Line 1: "Back to"
+    const text1 = "Back to";
+    const text1YBaseline = 4.2;
+    const text1Width = ctx.measureText(text1).width;
+    const x1_1 = commonTextX;
+    const y1_1 = text1YBaseline - commonTextHeight;
+    const x2_1 = commonTextX + text1Width;
+    const y2_1 = text1YBaseline;
+    const clickedLine1 = clickX >= x1_1 && clickX <= x2_1 && clickY >= y1_1 && clickY <= y2_1;
+
+    // Line 2: "OrygnsCode Home"
+    const text2 = "OrygnsCode Home";
+    const text2YBaseline = 5.0;
+    const text2Width = ctx.measureText(text2).width;
+    const x1_2 = commonTextX;
+    const y1_2 = text2YBaseline - commonTextHeight;
+    const x2_2 = commonTextX + text2Width;
+    const y2_2 = text2YBaseline;
+    const clickedLine2 = clickX >= x1_2 && clickX <= x2_2 && clickY >= y1_2 && clickY <= y2_2;
+
+    ctx.font = previousFont; // Restore previous font
+
+    if (clickedLine1 || clickedLine2) {
+        const homeLink = document.getElementById('homeLink');
+        if (homeLink) {
+            homeLink.click();
+        }
+    }
+});


### PR DESCRIPTION
This commit addresses issues with the "Back to OrygnsCode Home" link in the Tetris game UI.

Previously, the link was a single line, overlapped the game board, and the click detection was not always reliable.

Changes:
- **Layout Update (`drawUI()` in `script.js`):**
  - The "Back to OrygnsCode Home" text is now split into two lines:
    - "Back to"
    - "OrygnsCode Home"
  - These lines are positioned one below the other, directly under the "Tetris" title, ensuring they no longer overlap with the game board area.
  - Font size and family remain consistent with your original request (0.8px monospace).

- **Click Detection Update (event listener in `script.js`):**
  - The canvas click event listener has been updated to define two separate bounding boxes, one for each line of the link text ("Back to" and "OrygnsCode Home").
  - It now correctly checks if the click coordinates (scaled appropriately for the canvas) fall within *either* of these bounding boxes.
  - `ctx.measureText()` is used for each line to accurately determine its width for precise bounding box calculation.
  - If a click lands on either line, the navigation to the home page (via the hidden `homeLink` anchor tag) is triggered.

These changes should ensure the link is displayed correctly and functions as intended.