### PR TITLE
feat: Implement letter-by-letter pulse animation for header title

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 </head>
 <body>
     <header>
-        <h1>OrygnsCode</h1>
+        <h1><span class="title-letter">O</span><span class="title-letter">r</span><span class="title-letter">y</span><span class="title-letter">g</span><span class="title-letter">n</span><span class="title-letter">s</span><span class="title-letter">C</span><span class="title-letter">o</span><span class="title-letter">d</span><span class="title-letter">e</span></h1>
         <nav>
             <div id="day"></div>
             <div id="night"></div>
@@ -174,7 +174,7 @@
         </section>
 
         <section id="projects-showcase">
-            <h2 data-aos="fade-up">My Games</h2> 
+            <h2 data-aos="fade-up">My Games</h2>
             <div class="project-list">
                 <article class="project-item" data-aos="fade-up">
                     <h3>AstroDuel</h3>
@@ -242,11 +242,11 @@
         document.addEventListener('DOMContentLoaded', function() {
             // Ensure GSAP is loaded
             if (typeof gsap !== 'undefined') {
-                gsap.from(".hero h1", { 
-                    duration: 1, 
-                    y: 50, 
-                    opacity: 0, 
-                    ease: "power1.out", 
+                gsap.from(".hero h1", {
+                    duration: 1,
+                    y: 50,
+                    opacity: 0,
+                    ease: "power1.out",
                     delay: 0.5 // Delay to allow hero section fadeIn to occur
                 });
                 // Optional: Animate the hero paragraph as well with a slight delay
@@ -287,7 +287,7 @@
             function showNewMessage() {
                 if (messageElement) {
                     // Optional: fade out
-                    // messageElement.style.opacity = 0; 
+                    // messageElement.style.opacity = 0;
                     // setTimeout(() => {
                         currentMessageIndex = (currentMessageIndex + 1) % messages.length;
                         messageElement.textContent = messages[currentMessageIndex];
@@ -305,27 +305,53 @@
     <script>
     document.addEventListener('DOMContentLoaded', function() {
         if (typeof gsap !== 'undefined') {
-            const titleElement = document.querySelector('header h1');
+            const letters = document.querySelectorAll('header h1 .title-letter');
 
-            if (titleElement) {
-                // Set initial position explicitly to avoid jump if script runs late
-                gsap.set(titleElement, {xPercent: 0, yPercent: 0});
-                
-                const weaveDuration = 4; // Total duration of one weave
+            if (letters.length > 0) {
+                // Calculate approximate animation duration
+                // Number of letters: letters.length
+                // Stagger time for last letter to start: (letters.length - 1) * 0.15
+                // Pulse duration for one letter: 0.3 (up) + 0.3 (down) = 0.6
+                const staggerPerLetter = 0.15;
+                const pulseEffectDuration = 0.6; // 0.3s up + 0.3s down
+                const animationDuration = (letters.length > 0 ? ((letters.length - 1) * staggerPerLetter) + pulseEffectDuration : 0);
 
-                const snakeTl = gsap.timeline({
+                const desiredCycleTime = 5; // 5 seconds
+                const repeatDelayTime = desiredCycleTime - animationDuration;
+
+                const letterPulseTimeline = gsap.timeline({
                     repeat: -1, // Loop indefinitely
-                    repeatDelay: 10 - weaveDuration, // Wait for (10s - weaveDuration) after each full animation cycle
-                    defaults: { ease: "sine.inOut", duration: weaveDuration / 3 } // Default ease and duration for tweens
+                    repeatDelay: repeatDelayTime > 0 ? repeatDelayTime : 0 // Ensure delay is not negative
                 });
 
-                // Weave animation sequence
-                snakeTl.to(titleElement, { xPercent: -15, yPercent: -5 }) // Move left and slightly up
-                       .to(titleElement, { xPercent: 15, yPercent: 5 })   // Move right and slightly down
-                       .to(titleElement, { xPercent: 0, yPercent: 0 });  // Return to center
+                // Define the animation for a single letter pulse
+                // It will scale up and slightly lift, then return.
+                // Applied with a stagger to all letters.
+                letterPulseTimeline.to(letters, {
+                    scale: 1.3,
+                    yPercent: -20,
+                    opacity: 0.8,
+                    duration: 0.3,
+                    ease: "power1.out",
+                    stagger: {
+                        each: staggerPerLetter,
+                        from: "start"
+                    }
+                })
+                .to(letters, {
+                    scale: 1,
+                    yPercent: 0,
+                    opacity: 1,
+                    duration: 0.3,
+                    ease: "power1.in",
+                    stagger: {
+                        each: staggerPerLetter,
+                        from: "start"
+                    }
+                }, "-=0.15"); // Overlap for smoother word effect
             }
         } else {
-            console.warn("GSAP not loaded, skipping header title animation.");
+            console.warn("GSAP not loaded, skipping header title letter animation.");
         }
     });
     </script>

--- a/style.css
+++ b/style.css
@@ -114,7 +114,12 @@ header h1 {
     padding-left: 70px; /* Approx width of switch + its offset */
     padding-right: 70px; /* Approx width of switch + its offset */
     box-sizing: border-box; /* Include padding in width calculation */
-    position: relative; /* Ensures xPercent/yPercent transforms behave predictably */
+}
+
+header h1 .title-letter {
+    display: inline-block; /* Important for transforms to work as expected */
+    /* transform-origin: center center; /* GSAP usually handles this well, but can be explicit */
+    /* No extra margin/padding to avoid disrupting original letter spacing */
 }
 
 /* Nav is now absolutely positioned */


### PR DESCRIPTION
I've replaced the previous header title animation with a new effect where each letter of "OrygnsCode" pulses sequentially.

Here are the key changes:
- I reverted the previous 'weaving' GSAP animation for the `header h1` element and its associated CSS (`position: relative`).
- I modified `index.html`: Each letter in `header h1` ("OrygnsCode") is now wrapped in a `<span>` with class `title-letter` to allow individual animation.
- I added CSS for `.title-letter` in `style.css`, setting `display: inline-block` for proper transform behavior.
- I implemented a new GSAP animation in `index.html`:
    - It targets each `.title-letter` span.
    - It creates a "pulse" effect (scale, y-offset, opacity change).
    - It uses GSAP's stagger feature to apply the pulse sequentially to each letter.
    - The entire animation sequence for the word loops indefinitely with an approximate 5-second interval between the start of each full word pulse.
    - It includes checks for GSAP library availability.

This addresses your feedback to change the title animation to a per-letter pulsing effect.